### PR TITLE
Avoid calling WhereX in DoorInput

### DIFF
--- a/test.lpr
+++ b/test.lpr
@@ -20,7 +20,7 @@ begin
 
       DoorWriteLn();
       DoorWrite('Input Test: ');
-      S := DoorInput('Type something here', DOOR_INPUT_CHARS_ALPHA + ' ', #0, 40, 40, 31);
+      S := DoorInput('Type something here', DOOR_INPUT_CHARS_ALPHA + ' ', #0, 20, 40, 31);
       DoorWriteLn('You typed: ' + S);
 
       DoorWriteLn();


### PR DESCRIPTION
On linux in stdio mode WhereX always returns 1 because we're writing to StdOut and bypassing the virtual screen buffer. This modified version tracks the x-offset for the current input instead, avoiding the need to call WhereX